### PR TITLE
Update 2022_02_14_GraphLaplacian.ipynb

### DIFF
--- a/CS328-Notes/notebooks/2022_02_14_GraphLaplacian.ipynb
+++ b/CS328-Notes/notebooks/2022_02_14_GraphLaplacian.ipynb
@@ -153,7 +153,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### What if the graph is disconnected?\n",
+    "#### What if the graph is not disconnected?\n",
     "\n",
     "$ \\hspace{7mm} \\lambda_2(L) $ will still give a \"measure of how much, $ G $ resembles a 2 disconnected components, i.e., sparsest cut\"."
    ]


### PR DESCRIPTION
the statement written is wrong, it should be "What if the graph is not disconnected?" - it gives sparsest cut

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://cs328-2022.github.io/CS328-Notes/notebooks/CONTRIBUTING.html
-->

<!-- Please make sure the name of files is in format yyyy_mm_dd_topic_name -->

#### Lectures
<!-- Date here means, the date when the specific lecture was conducted -->
- `<Date 1 dd/mm/yy/day>` : `<Topic 1>` : `<Name of corresponding file with extension>`
- `<Date 2 dd/mm/yy/day>` : `<Topic 2>` : `<Name of corresponding file with extension>`
- `<Date 3 dd/mm/yy/day>` : `<Topic 3>` : `<Name of corresponding file with extension>`

#### Group Seq Number
<!-- As per the table at https://cs328-2022.github.io/CS328-Notes/notebooks/deadlines.html -->
`<seq>`

#### Assigned Deadline
<!-- As per the table at https://cs328-2022.github.io/CS328-Notes/notebooks/deadlines.html -->
`<dd/mm/yy/day>`

#### Members
- `<Member 1 Name>` : `<Member 1 Roll Number>` : `<Member 1 email>` : `<Member 1 github username>`
- `<Member 2 Name>` : `<Member 2 Roll Number>` : `<Member 2 email>` : `<Member 2 github username>`
- `<Member 3 Name>` : `<Member 3 Roll Number>` : `<Member 3 email>` : `<Member 3 github username>`

#### Any other comments?

<!-- In each of the new markdown/notebook files created by your group; please mention all the group members.
At the end of each file, add this footer HTML tag.
<footer>
Author(s): Member 1 Name, Member 2 Name, Member 3 Name
</footer>
 -->
